### PR TITLE
Added EXR support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ transformers==4.32.1
 triton==2.0.0
 wandb==0.14.0
 xformers==0.0.21
+pyroexr

--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@
 
 import argparse
 import os
+os.environ['OPENCV_IO_ENABLE_OPENEXR'] = '1'
 from glob import glob
 
 import cv2
@@ -88,10 +89,12 @@ if "__main__" == __name__:
     output_dir_color = os.path.join(output_dir, "depth_colored")
     output_dir_png = os.path.join(output_dir, "depth_bw")
     output_dir_npy = os.path.join(output_dir, "depth_npy")
+    output_dir_exr = os.path.join(output_dir, "depth_exr")
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(output_dir_color, exist_ok=True)
     os.makedirs(output_dir_png, exist_ok=True)
     os.makedirs(output_dir_npy, exist_ok=True)
+    os.makedirs(output_dir_exr, exist_ok=True)
     print(f"output dir: {output_dir}")
 
     # Device
@@ -181,6 +184,10 @@ if "__main__" == __name__:
             pred_name_base = rgb_name_base + "_pred"
             save_to_npy = os.path.join(output_dir_npy, f"{pred_name_base}.npy")
             np.save(save_to_npy, depth_pred)
+
+            # Save as exr
+            save_to_exr = os.path.join(output_dir_exr, f"{pred_name_base}.exr")
+            cv2.imwrite(save_to_exr, depth_pred)
 
             # Save as 16uint png
             save_to_png = os.path.join(output_dir_png, f"{pred_name_base}.png")

--- a/run.py
+++ b/run.py
@@ -198,7 +198,7 @@ if "__main__" == __name__:
 
             # Save as npy
             rgb_name_base = os.path.splitext(os.path.basename(rgb_path))[0]
-            pred_name_base = rgb_name_base + "_pred"
+            pred_name_base = rgb_name_base + ""
             save_to_npy = os.path.join(output_dir_npy, f"{pred_name_base}.npy")
             np.save(save_to_npy, depth_pred)
 

--- a/src/util/image_util.py
+++ b/src/util/image_util.py
@@ -3,6 +3,7 @@ import matplotlib
 import numpy as np
 import torch
 from PIL import Image
+import cv2
 
 def colorize_depth_maps(depth_map, min_depth, max_depth, cmap='Spectral', valid_mask=None):
     """
@@ -52,14 +53,21 @@ def chw2hwc(chw):
     return hwc
 
 
-def resize_max_res(img: Image.Image, max_edge_resolution):
-    original_width, original_height = img.size
-    downscale_factor = min(max_edge_resolution / original_width, max_edge_resolution / original_height)
-    
-    new_width = int(original_width * downscale_factor)
-    new_height = int(original_height * downscale_factor)
-    
-    resized_img = img.resize((new_width, new_height))
+def resize_max_res(img: Image.Image | np.ndarray, max_edge_resolution):
+    if type(img) == np.ndarray:
+        original_height, original_width = img.shape[:2]
+        downscale_factor = min(max_edge_resolution / original_width, max_edge_resolution / original_height)
+        new_width = int(original_width * downscale_factor)
+        new_height = int(original_height * downscale_factor)
+        resized_img = cv2.resize(img, (new_width, new_height), cv2.INTER_LINEAR)
+    else:
+        original_width, original_height = img.size
+        downscale_factor = min(max_edge_resolution / original_width, max_edge_resolution / original_height)
+        
+        new_width = int(original_width * downscale_factor)
+        new_height = int(original_height * downscale_factor)
+        
+        resized_img = img.resize((new_width, new_height))
     return resized_img
     
     


### PR DESCRIPTION
The `run.py` now can read EXR files and write EXR files. It creates an extra folder for saving the EXR with float32 precision, which are ready to be used in current VFX pipelines. It also clamps the input to 0-1, a more interesting approach may be to use logarithmic color space but that is shot dependant so I did not include it.